### PR TITLE
fix(db): make  migration idempotent

### DIFF
--- a/backend/migrations/versions/944a096f3c16_add_forecast_results.py
+++ b/backend/migrations/versions/944a096f3c16_add_forecast_results.py
@@ -7,22 +7,44 @@ down_revision = "82993df14451"
 branch_labels = None
 depends_on = None
 
+
 def upgrade():
-    op.create_table(
-        "forecast_results",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("source_id", sa.Integer(), sa.ForeignKey("sources.id", ondelete="CASCADE"), nullable=False),
-        sa.Column("metric", sa.String(length=64), nullable=False),
-        sa.Column("target_date", sa.Date(), nullable=False),
-        sa.Column("yhat", sa.Float(), nullable=False),
-        sa.Column("yhat_lower", sa.Float(), nullable=True),
-        sa.Column("yhat_upper", sa.Float(), nullable=True),
-        sa.Column("model_version", sa.String(length=32), nullable=True),
-    )
-    op.create_unique_constraint(
-        "uq_forecast_day", "forecast_results", ["source_id", "metric", "target_date"]
-    )
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    table_name = "forecast_results"
+    uc_name = "uq_forecast_day"
+
+    existing_tables = set(insp.get_table_names())
+    if table_name not in existing_tables:
+        op.create_table(
+            table_name,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("source_id", sa.Integer(), sa.ForeignKey("sources.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("metric", sa.String(length=64), nullable=False),
+            sa.Column("target_date", sa.Date(), nullable=False),
+            sa.Column("yhat", sa.Float(), nullable=False),
+            sa.Column("yhat_lower", sa.Float(), nullable=True),
+            sa.Column("yhat_upper", sa.Float(), nullable=True),
+            sa.Column("model_version", sa.String(length=32), nullable=True),
+        )
+
+    # (Re)check unique constraints and create only if missing
+    existing_ucs = {uc["name"] for uc in insp.get_unique_constraints(table_name)}
+    if uc_name not in existing_ucs:
+        op.create_unique_constraint(uc_name, table_name, ["source_id", "metric", "target_date"])
+
 
 def downgrade():
-    op.drop_constraint("uq_forecast_day", "forecast_results", type_="unique")
-    op.drop_table("forecast_results")
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    table_name = "forecast_results"
+    uc_name = "uq_forecast_day"
+
+    existing_tables = set(insp.get_table_names())
+    if table_name in existing_tables:
+        existing_ucs = {uc["name"] for uc in insp.get_unique_constraints(table_name)}
+        if uc_name in existing_ucs:
+            op.drop_constraint(uc_name, table_name, type_="unique")
+        op.drop_table(table_name)


### PR DESCRIPTION
Guard CREATE TABLE and unique constraint with SQLAlchemy inspector.
- Avoids DuplicateTable/DuplicateConstraint errors on pre-provisioned DBs (e.g., test env).
- No runtime behavior change; only affects Alembic execution on upgrade/downgrade.

Details:
- File: backend/migrations/versions/944a096f3c16_add_forecast_results.py
- Table: forecast_results (id, source_id, metric, target_date, yhat, yhat_lower, yhat_upper, model_version)
- Unique constraint: uq_forecast_day on (source_id, metric, target_date)

Verification:
- DEV: `alembic downgrade -1 && alembic upgrade head`
- TEST: `export DATABASE_URL=$TEST_DATABASE_URL` then same 
- Confirmed schema via `\d forecast_results`
- Test suite passes (coverage ~75%)

Risk/Impact:
- Low; backwards-compatible migration. Fresh DBs still create table/UC; existing DBs safely no-op.