### PR TITLE
add data fetching hooks for MetricDaily, Anomalies, and Forecast

### DIFF
--- a/frontend/src/hooks/useAnomalies.ts
+++ b/frontend/src/hooks/useAnomalies.ts
@@ -1,0 +1,47 @@
+import { useEffect, useMemo, useState } from "react";
+import { getJson } from "../lib/api";
+import type { AnomalyPoint, ISODate } from "../types/metrics";
+
+export interface AnomalyParams {
+  source_name: string;
+  metric: string;
+  start_date?: ISODate;
+  end_date?: ISODate;
+  window?: number;         // rolling window (e.g., 7)
+  z_thresh?: number;       // z-threshold (e.g., 2)
+}
+
+export function useAnomalies(params: AnomalyParams, enabled = true) {
+  const [data, setData] = useState<AnomalyPoint[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const stableParams = useMemo(
+    () => ({ ...params }),
+    [params.source_name, params.metric, params.start_date, params.end_date, params.window, params.z_thresh]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const ctrl = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    getJson<AnomalyPoint[]>("/api/metrics/anomaly/rolling", stableParams, ctrl.signal)
+      .then((rows) => setData(rows))
+      .catch((e) => {
+        if (e.name !== "AbortError") setError(e as Error);
+      })
+      .finally(() => setLoading(false));
+
+    return () => ctrl.abort();
+  }, [stableParams, enabled]);
+
+  return { data, loading, error };
+}

--- a/frontend/src/hooks/useForecast.ts
+++ b/frontend/src/hooks/useForecast.ts
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useState } from "react";
+import { getJson } from "../lib/api";
+import type { ForecastPoint, ISODate } from "../types/metrics";
+
+export interface ForecastParams {
+  source_name: string;
+  metric: string;
+  start_date?: ISODate; // used to align/clip
+  end_date?: ISODate;   // used to align/clip
+}
+
+export function useForecast(params: ForecastParams, enabled = true) {
+  const [data, setData] = useState<ForecastPoint[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const stableParams = useMemo(
+    () => ({ ...params }),
+    [params.source_name, params.metric, params.start_date, params.end_date]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const ctrl = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    getJson<ForecastPoint[]>("/api/forecast/daily", stableParams, ctrl.signal)
+      .then((rows) => setData(rows))
+      .catch((e) => {
+        if (e.name !== "AbortError") setError(e as Error);
+      })
+      .finally(() => setLoading(false));
+
+    return () => ctrl.abort();
+  }, [stableParams, enabled]);
+
+  return { data, loading, error };
+}

--- a/frontend/src/hooks/useMetricDaily.ts
+++ b/frontend/src/hooks/useMetricDaily.ts
@@ -1,0 +1,36 @@
+import { useEffect, useMemo, useState } from "react";
+import { getJson } from "../lib/api";
+import type { MetricDailyRow, ISODate } from "../types/metrics";
+
+export interface MetricDailyParams {
+  source_name: string;
+  metric: string;
+  start_date?: ISODate;
+  end_date?: ISODate;
+  agg?: "sum" | "avg" | "count" | "distinct";
+}
+
+export function useMetricDaily(params: MetricDailyParams) {
+  const [data, setData] = useState<MetricDailyRow[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const stableParams = useMemo(() => ({ ...params }), [params.source_name, params.metric, params.start_date, params.end_date, params.agg]);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    getJson<MetricDailyRow[]>("/api/metrics/daily", stableParams, ctrl.signal)
+      .then((rows) => setData(rows))
+      .catch((e) => {
+        if (e.name !== "AbortError") setError(e as Error);
+      })
+      .finally(() => setLoading(false));
+
+    return () => ctrl.abort();
+  }, [stableParams]);
+
+  return { data, loading, error };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,20 @@
+const API_BASE = import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000";
+
+export function buildUrl(path: string, params?: Record<string, string | number | undefined>) {
+  const url = new URL(path.startsWith("http") ? path : `${API_BASE}${path}`);
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && v !== "") url.searchParams.set(k, String(v));
+    });
+  }
+  return url.toString();
+}
+
+export async function getJson<T>(path: string, params?: Record<string, any>, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(buildUrl(path, params), { signal });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`GET ${path} failed: ${res.status} ${res.statusText} ${text ? `- ${text}` : ""}`);
+  }
+  return res.json() as Promise<T>;
+}

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -1,0 +1,29 @@
+export type ISODate = string; // 'YYYY-MM-DD'
+
+export interface MetricDailyRow {
+  metric_date: ISODate;
+  source: string;
+  metric: string;     // e.g., "events_total"
+  value_sum?: number | null;
+  value_avg?: number | null;
+  value_count?: number | null;
+  value_distinct?: number | null;
+}
+
+export interface AnomalyPoint {
+  metric_date: ISODate;
+  metric: string;
+  source: string;
+  value: number;
+  z?: number | null;         // rolling z-score
+  is_anomaly: boolean;       // true where z > threshold (server or client)
+}
+
+export interface ForecastPoint {
+  target_date: ISODate;
+  metric: string;
+  source: string;
+  yhat: number;
+  yhat_lower?: number | null;
+  yhat_upper?: number | null;
+}


### PR DESCRIPTION
Introduces reusable React hooks (useMetricDaily, useAnomalies, useForecast) and a small api.ts helper to centralize dashboard data fetching. MetricDailyCard.tsx now consumes these hooks, simplifying effects and improving readability. This prepares the codebase for Monday’s container/view split and future UI work. Includes types in types/metrics.ts for safer data handling.