### PR TITLE
feat(dashboard): forecast toggle reliability + dynamic sources (DashboardPage only)

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -12,36 +12,87 @@ const API_BASE = "";
 
 /* ---------- types ---------- */
 type Row = {
-  metric_date?: string; date?: string; day?: string;
-  source_id?: number | string; source?: string;
-  metric?: string; name?: string;
-  value_sum?: number; sum?: number; total?: number; value?: number;
-  value_avg?: number; avg?: number; mean?: number; average?: number;
-  value_count?: number; count?: number; rows?: number; n?: number;
-  value_distinct?: number; distinct?: number; unique?: number;
+  metric_date?: string;
+  date?: string;
+  day?: string;
+  source_id?: number | string;
+  source?: string;
+  metric?: string;
+  name?: string;
+  value_sum?: number;
+  sum?: number;
+  total?: number;
+  value?: number;
+  value_avg?: number;
+  avg?: number;
+  mean?: number;
+  average?: number;
+  value_count?: number;
+  count?: number;
+  rows?: number;
+  n?: number;
+  value_distinct?: number;
+  distinct?: number;
+  unique?: number;
 };
 type AnomPoint = { date: string; value: number; z?: number };
 type ForecastPoint = { date: string; yhat: number };
+type Source = { id: number | string; name: string };
 
 /* ---------- helpers ---------- */
-function isoDaysAgo(n: number) { const d=new Date(); d.setDate(d.getDate()-n); return d.toISOString().slice(0,10); }
-function pick<T extends object, K extends keyof any>(o: T, ...ks: K[]) { for (const k of ks) { const v=(o as any)[k]; if (v!=null) return v; } }
-function getDate(r: Row) { return (pick(r,"metric_date","date","day") as string | undefined) ?? undefined; }
-function num(v: any) { const n=Number(v); return Number.isFinite(n)?n:0; }
+function isoDaysAgo(n: number) {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+function pick<T extends object, K extends keyof any>(o: T, ...ks: K[]) {
+  for (const k of ks) {
+    const v = (o as any)[k];
+    if (v != null) return v;
+  }
+}
+function getDate(r: Row) {
+  return (
+    (pick(r, "metric_date", "date", "day") as string | undefined) ?? undefined
+  );
+}
+function num(v: any) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
 
 /* ---------- overlays: anomalies & forecast ---------- */
 async function fetchAnomalies(params: {
-  sourceName: string; metric: string; start?: string; end?: string;
-  windowN?: number; zThresh?: number; signal?: AbortSignal;
+  sourceName: string;
+  metric: string;
+  start?: string;
+  end?: string;
+  windowN?: number;
+  zThresh?: number;
+  signal?: AbortSignal;
 }): Promise<AnomPoint[]> {
-  const { sourceName, metric, start, end, windowN = 7, zThresh = 3, signal } = params;
-  const qs = new URLSearchParams({ source_name: String(sourceName), metric: String(metric) });
+  const {
+    sourceName,
+    metric,
+    start,
+    end,
+    windowN = 7,
+    zThresh = 3,
+    signal,
+  } = params;
+  const qs = new URLSearchParams({
+    source_name: String(sourceName),
+    metric: String(metric),
+  });
   if (start) qs.set("start_date", start);
   if (end) qs.set("end_date", end);
   qs.set("window", String(windowN));
   qs.set("z_thresh", String(zThresh));
 
-  const r = await fetch(`${API_BASE}/api/metrics/anomaly/rolling?${qs.toString()}`, { signal });
+  const r = await fetch(
+    `${API_BASE}/api/metrics/anomaly/rolling?${qs.toString()}`,
+    { signal },
+  );
   if (!r.ok) throw new Error(`HTTP ${r.status}`);
   const js: any = await r.json();
 
@@ -53,12 +104,30 @@ async function fetchAnomalies(params: {
   else if (Array.isArray(js?.anomalies)) raw = js.anomalies;
   else if (Array.isArray(js?.data?.points)) raw = js.data.points;
   else if (Array.isArray(js?.dates) && Array.isArray(js?.values)) {
-    const dates = js.dates, values = js.values, zArr = Array.isArray(js?.z) ? js.z : [];
-    raw = dates.map((d: any, i: number) => ({ date: d, value: values[i], z: zArr[i] }));
+    const dates = js.dates,
+      values = js.values,
+      zArr = Array.isArray(js?.z) ? js.z : [];
+    raw = dates.map((d: any, i: number) => ({
+      date: d,
+      value: values[i],
+      z: zArr[i],
+    }));
   } else if (js && typeof js === "object") {
     const maybe = Object.entries(js)
-      .filter(([k, v]) => typeof v === "object" && (/[0-9]{4}-[0-9]{2}-[0-9]{2}/.test(k) || "metric_date" in (v as any) || "date" in (v as any)))
-      .map(([k, v]: any) => ({ date: v.metric_date ?? v.date ?? k, value: v.value ?? v.value_sum ?? v.y ?? v.count ?? 0, z: v.z ?? v.score, flagged: v.is_anomaly ?? v.is_outlier ?? v.anomaly ?? v.outlier ?? v.flagged }));
+      .filter(
+        ([k, v]) =>
+          typeof v === "object" &&
+          (/[0-9]{4}-[0-9]{2}-[0-9]{2}/.test(k) ||
+            "metric_date" in (v as any) ||
+            "date" in (v as any)),
+      )
+      .map(([k, v]: any) => ({
+        date: v.metric_date ?? v.date ?? k,
+        value: v.value ?? v.value_sum ?? v.y ?? v.count ?? 0,
+        z: v.z ?? v.score,
+        flagged:
+          v.is_anomaly ?? v.is_outlier ?? v.anomaly ?? v.outlier ?? v.flagged,
+      }));
     if (maybe.length) raw = maybe;
   }
   if (!Array.isArray(raw)) return [];
@@ -66,12 +135,21 @@ async function fetchAnomalies(params: {
   const pts: AnomPoint[] = raw
     .map((row: any) => {
       const date = String(row.metric_date ?? row.date ?? row.ts ?? "");
-      const value = Number(row.value ?? row.value_sum ?? row.y ?? row.count ?? 0);
+      const value = Number(
+        row.value ?? row.value_sum ?? row.y ?? row.count ?? 0,
+      );
       const flagged =
-        row.is_outlier === true || row.is_anomaly === true ||
-        row.outlier === true    || row.anomaly === true    ||
+        row.is_outlier === true ||
+        row.is_anomaly === true ||
+        row.outlier === true ||
+        row.anomaly === true ||
         row.flagged === true;
-      const z = typeof row.z === "number" ? row.z : (typeof row.score === "number" ? row.score : undefined);
+      const z =
+        typeof row.z === "number"
+          ? row.z
+          : typeof row.score === "number"
+            ? row.score
+            : undefined;
       return { date, value, z, flagged } as any;
     })
     .filter((p: any) => {
@@ -85,44 +163,61 @@ async function fetchAnomalies(params: {
 }
 
 const FC_CACHE = new Map<string, ForecastPoint[]>();
-  async function fetchForecast(
-    sourceName: string,
-    metric: string,
-    start?: string,
-    end?: string,
-    signal?: AbortSignal,
-    horizon?: number  // <— NEW
-  ): Promise<ForecastPoint[]> {
-    const key = `fc:${sourceName}:${metric}:${start}:${end}:${horizon ?? "n"}`;
-    if (FC_CACHE.has(key)) return FC_CACHE.get(key)!;
+async function fetchForecast(
+  sourceName: string,
+  metric: string,
+  start?: string,
+  end?: string,
+  signal?: AbortSignal,
+  horizon?: number,
+  nonce?: number,
+): Promise<ForecastPoint[]> {
+  const key = `fc:${sourceName}:${metric}:${start}:${end}:${horizon ?? "n"}:${nonce ?? 0}`;
+  if (FC_CACHE.has(key)) return FC_CACHE.get(key)!;
 
-    const qs = new URLSearchParams({ source_name: String(sourceName), metric: String(metric) });
+  const qs = new URLSearchParams({
+    source_name: String(sourceName),
+    metric: String(metric),
+  });
 
-    // Prefer horizon (so we get 7 points), otherwise legacy start/end
-    if (horizon && horizon > 0) {
-      qs.set("horizon", String(Math.min(30, Math.max(1, horizon))));
-    } else {
-      if (start) qs.set("start_date", start);
-      if (end) qs.set("end_date", end);
-    }
-
-    const r = await fetch(`${API_BASE}/api/forecast/daily?${qs.toString()}`, { signal });
-    if (!r.ok) throw new Error(`HTTP ${r.status}`);
-
-    const js: any = await r.json();
-    const raw: any[] = Array.isArray(js) ? js : js.data ?? js.points ?? js?.data?.points ?? [];
-
-    const fc: ForecastPoint[] = raw
-      .map((row: any) => ({
-        // read the new key first
-        date: String(row.forecast_date ?? row.target_date ?? row.metric_date ?? row.date ?? row.ts ?? ""),
-        yhat: Number(row.yhat ?? row.y_pred ?? row.prediction ?? row.value ?? row.y ?? NaN),
-      }))
-      .filter((p) => p.date && Number.isFinite(p.yhat));
-
-    FC_CACHE.set(key, fc);
-    return fc;
+  // Prefer horizon (so we get 7 points), otherwise legacy start/end
+  if (horizon && horizon > 0) {
+    qs.set("horizon", String(Math.min(30, Math.max(1, horizon))));
+  } else {
+    if (start) qs.set("start_date", start);
+    if (end) qs.set("end_date", end);
   }
+
+  if (nonce) qs.set("nocache", String(nonce));
+  const r = await fetch(`${API_BASE}/api/forecast/daily?${qs.toString()}`, {
+    signal,
+  });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+
+  const js: any = await r.json();
+  const raw: any[] = Array.isArray(js)
+    ? js
+    : (js.data ?? js.points ?? js?.data?.points ?? []);
+
+  const fc: ForecastPoint[] = raw
+    .map((row: any) => ({
+      date: String(
+        row.forecast_date ??
+          row.target_date ??
+          row.metric_date ??
+          row.date ??
+          row.ts ??
+          "",
+      ),
+      yhat: Number(
+        row.yhat ?? row.y_pred ?? row.prediction ?? row.value ?? row.y ?? NaN,
+      ),
+    }))
+    .filter((p) => p.date && Number.isFinite(p.yhat));
+
+  FC_CACHE.set(key, fc);
+  return fc;
+}
 
 /* ---------- page ---------- */
 export default function DashboardPage() {
@@ -131,7 +226,12 @@ export default function DashboardPage() {
   const [metric, setMetric] = useState("events_total");
   const [start, setStart] = useState(() => isoDaysAgo(6));
   const [end, setEnd] = useState(() => isoDaysAgo(0));
-  const [dateRange, setDateRange] = useState<"7"|"14"|"30">("7");
+  const [dateRange, setDateRange] = useState<"7" | "14" | "30">("7");
+
+  // Sources / metric names (dynamic)
+  const [sources, setSources] = useState<Source[]>([]);
+  const sourceNamesKey = sources.map((s) => s.name).join(",");
+  const [metricOptions, setMetricOptions] = useState<string[]>([]);
 
   // Toggles + anomaly params
   const [showAnoms, setShowAnoms] = useState(false);
@@ -143,13 +243,69 @@ export default function DashboardPage() {
   const [rows, setRows] = useState<Row[]>([]);
   const [anoms, setAnoms] = useState<AnomPoint[]>([]);
   const [forecast, setForecast] = useState<ForecastPoint[]>([]);
+  const [fcTick, setFcTick] = useState(0); // nonce to force one refetch when toggled ON
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Clear forecast cache on filter changes so a subsequent toggle ON refetches
+  useEffect(() => {
+    FC_CACHE.clear();
+  }, [sourceName, metric, start, end]);
 
   /* ---------- upload state ---------- */
   const fileRef = useRef<HTMLInputElement | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadMsg, setUploadMsg] = useState<string | null>(null);
+
+  /* ---------- load sources + metric names ---------- */
+  async function loadSources() {
+    const r = await fetch(`${API_BASE}/api/sources`, { cache: "no-store" });
+    const js: any = await r.json();
+    const arr: any[] = Array.isArray(js)
+      ? js
+      : Array.isArray(js?.data)
+        ? js.data
+        : [];
+    const data: Source[] = arr.map((s: any) =>
+      typeof s === "string"
+        ? { id: s, name: s }
+        : { id: s.id ?? s.name, name: s.name ?? String(s) },
+    );
+    setSources(data);
+    if (data.length && !data.find((s) => s.name === sourceName)) {
+      setSourceName(data[0].name);
+    }
+    console.log(
+      "loadSources →",
+      data.map((s) => s.name),
+    );
+  }
+  useEffect(() => {
+    void loadSources();
+  }, []);
+
+  async function loadMetricNames(sn: string) {
+    if (!sn) {
+      setMetricOptions([]);
+      return;
+    }
+    try {
+      const r = await fetch(
+        `${API_BASE}/api/metrics/names?source_name=${encodeURIComponent(sn)}`,
+        { cache: "no-store" },
+      );
+      if (!r.ok) throw new Error(String(r.status));
+      const names: string[] = await r.json();
+      setMetricOptions(names || []);
+      if (names?.length && !names.includes(metric)) setMetric(names[0]);
+      console.log("metric names for", sn, "→", names);
+    } catch {
+      setMetricOptions([]);
+    }
+  }
+  useEffect(() => {
+    void loadMetricNames(sourceName);
+  }, [sourceName]);
 
   // Quick range fills fields; still editable
   useEffect(() => {
@@ -160,27 +316,39 @@ export default function DashboardPage() {
 
   // KPIs
   const kpis = useMemo(() => {
-    let sum=0, avg=0, cnt=0, dst=0, n=0;
+    let sum = 0,
+      avg = 0,
+      cnt = 0,
+      dst = 0,
+      n = 0;
     for (const r of rows) {
-      sum += num(pick(r,"value_sum","sum","total","value"));
-      avg += num(pick(r,"value_avg","avg","mean","average"));
-      cnt += num(pick(r,"value_count","count","rows","n"));
-      dst += num(pick(r,"value_distinct","distinct","unique"));
+      sum += num(pick(r, "value_sum", "sum", "total", "value"));
+      avg += num(pick(r, "value_avg", "avg", "mean", "average"));
+      cnt += num(pick(r, "value_count", "count", "rows", "n"));
+      dst += num(pick(r, "value_distinct", "distinct", "unique"));
       n++;
     }
     return {
       sum,
-      avg: n ? +(avg/n).toFixed(2) : 0,
+      avg: n ? +(avg / n).toFixed(2) : 0,
       count: cnt,
       distinct: dst || 0,
-      hasDistinct: rows.some(r => pick(r,"value_distinct","distinct","unique")!=null),
+      hasDistinct: rows.some(
+        (r) => pick(r, "value_distinct", "distinct", "unique") != null,
+      ),
     };
   }, [rows]);
 
   /* ---------- effect-driven base fetch ---------- */
-  const query = useMemo(() => ({
-    sourceName, metric, start, end
-  }), [sourceName, metric, start, end]);
+  const query = useMemo(
+    () => ({
+      sourceName,
+      metric,
+      start,
+      end,
+    }),
+    [sourceName, metric, start, end],
+  );
 
   useEffect(() => {
     // Clear UI immediately to avoid stale series/rows
@@ -192,23 +360,29 @@ export default function DashboardPage() {
     const ctrl = new AbortController();
     const load = async () => {
       try {
-        if (start && end && start > end) throw new Error("Start must be on/before End.");
+        if (start && end && start > end)
+          throw new Error("Start must be on/before End.");
         setLoading(true);
 
-        const qs = new URLSearchParams({ source_name: String(sourceName), metric: String(metric) });
+        const qs = new URLSearchParams({
+          source_name: String(sourceName),
+          metric: String(metric),
+        });
         if (start) qs.set("start_date", start);
         if (end) qs.set("end_date", end);
 
-        const r = await fetch(`${API_BASE}/api/metrics/daily?${qs.toString()}`, { signal: ctrl.signal });
+        const r = await fetch(
+          `${API_BASE}/api/metrics/daily?${qs.toString()}`,
+          { signal: ctrl.signal },
+        );
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         const js = await r.json();
-        const arr: Row[] = Array.isArray(js) ? js : js.items ?? js.data ?? [];
-        arr.sort((a,b)=>(getDate(a)||"").localeCompare(getDate(b)||""));
+        const arr: Row[] = Array.isArray(js) ? js : (js.items ?? js.data ?? []);
+        arr.sort((a, b) => (getDate(a) || "").localeCompare(getDate(b) || ""));
         setRows(arr);
-      } catch (e:any) {
-        if (e?.name !== "AbortError") {
+      } catch (e: any) {
+        if (e?.name !== "AbortError")
           setError(e?.message || "Failed to load data");
-        }
       } finally {
         setLoading(false);
       }
@@ -224,31 +398,61 @@ export default function DashboardPage() {
     const ctrl = new AbortController();
 
     const loadOverlays = async () => {
-      if (!rows.length) { setAnoms([]); setForecast([]); return; }
+      if (!rows.length) {
+        setAnoms([]);
+        setForecast([]);
+        return;
+      }
       try {
         if (showAnoms) {
           const pts = await fetchAnomalies({
-            sourceName, metric, start, end, windowN, zThresh, signal: ctrl.signal
+            sourceName,
+            metric,
+            start,
+            end,
+            windowN,
+            zThresh,
+            signal: ctrl.signal,
           });
           setAnoms(pts);
         } else setAnoms([]);
 
         if (showForecast) {
           const H = 7;
-          const fc = await fetchForecast(sourceName, metric, undefined, undefined, ctrl.signal, H);
-            setForecast(fc);
-          } else {
-            setForecast([]);
-          }
-      } catch (e:any) {
-        if (e?.name !== "AbortError") setError(e?.message || "Overlay fetch failed");
+          const fc = await fetchForecast(
+            sourceName,
+            metric,
+            undefined,
+            undefined,
+            ctrl.signal,
+            H,
+            fcTick,
+          );
+          setForecast(fc);
+        } else {
+          setForecast([]);
+        }
+      } catch (e: any) {
+        if (e?.name !== "AbortError")
+          setError(e?.message || "Overlay fetch failed");
       }
     };
 
     void loadOverlays();
     return () => ctrl.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rows.length, showAnoms, showForecast, windowN, zThresh, sourceName, metric, start, end]);
+  }, [
+    rows.length,
+    showAnoms,
+    showForecast,
+    windowN,
+    zThresh,
+    sourceName,
+    metric,
+    start,
+    end,
+    fcTick,
+  ]);
 
   /* ---------- Upload handler (calls /api/ingest) ---------- */
   async function handleUpload(file: File | null) {
@@ -256,21 +460,17 @@ export default function DashboardPage() {
     setUploading(true);
     setUploadMsg(null);
     try {
-      const isJson = file.type?.toLowerCase().includes("json") || file.name.endsWith(".json");
+      const isJson =
+        file.type?.toLowerCase().includes("json") ||
+        file.name.endsWith(".json");
       const contentType = isJson ? "application/json" : "text/csv";
       const body = await file.text();
-        await fetch(`/api/ingest?source_name=${encodeURIComponent(sourceName)}&default_metric=${encodeURIComponent(metric)}`, {
-          method: "POST",
-          headers: { "Content-Type": "text/csv" },
-          body,
-        });
 
-      const qs = new URLSearchParams({
+      const qsUp = new URLSearchParams({
         source_name: String(sourceName || "demo-source"),
         default_metric: String(metric || "events_total"),
       });
-
-      const resp = await fetch(`${API_BASE}/api/ingest?${qs.toString()}`, {
+      const resp = await fetch(`${API_BASE}/api/ingest?${qsUp.toString()}`, {
         method: "POST",
         headers: { "Content-Type": contentType },
         body,
@@ -278,22 +478,25 @@ export default function DashboardPage() {
 
       const js = await resp.json().catch(() => ({}));
       if (!resp.ok || js?.ok === false) {
-        throw new Error(js?.error?.message || `Upload failed (HTTP ${resp.status})`);
+        throw new Error(
+          js?.error?.message || `Upload failed (HTTP ${resp.status})`,
+        );
       }
 
-      // Optionally kick KPI recompute (harmless if backend already did it)
-      await fetch(`${API_BASE}/api/kpi/run?source_name=${encodeURIComponent(sourceName)}&metric=${encodeURIComponent(metric)}`, {
+      await fetch(`${API_BASE}/api/kpi/run`, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source_name: sourceName, metric }),
       }).catch(() => {});
 
       setUploadMsg(
         `Ingested ${js?.data?.ingested_rows ?? js?.ingested_rows ?? "?"} rows` +
-        (js?.duplicates ? `, ${js.duplicates} duplicates` : "") +
-        ` (${file.name}).`
+          (js?.duplicates ? `, ${js.duplicates} duplicates` : "") +
+          ` (${file.name}).`,
       );
 
-      // Nudge base effect to re-fetch without changing filters
-      setEnd(e => e);
+      setEnd((e) => e); // nudge base effect
+      void loadMetricNames(sourceName); // refresh metric list
     } catch (e: any) {
       setUploadMsg(e?.message || "Upload failed.");
     } finally {
@@ -302,99 +505,178 @@ export default function DashboardPage() {
     }
   }
 
-  /* ---------- Reset handler (pure state; effect does the fetch) ---------- */
+  /* ---------- Reset handler ---------- */
   function handleReset() {
     const newStart = isoDaysAgo(6);
-    const newEnd   = isoDaysAgo(0);
-
-    // Set defaults. The base effect above will clear data and fetch once.
+    const newEnd = isoDaysAgo(0);
     setSourceName("demo-source");
     setMetric("events_total");
-    setDateRange("7"); // will also update start/end via its effect
+    setDateRange("7");
     setStart(newStart);
     setEnd(newEnd);
-
     setShowAnoms(false);
     setShowForecast(false);
     setWindowN(7);
     setZThresh(3);
   }
 
-  /* ---------- chart remount key to avoid stale series ---------- */
+  /* ---------- chart remount key ---------- */
   const chartKey = useMemo(
-    () => `${sourceName}|${metric}|${start}|${end}|${showAnoms}|${showForecast}`,
-    [sourceName, metric, start, end, showAnoms, showForecast]
+    () =>
+      `${sourceName}|${metric}|${start}|${end}|${showAnoms}|${showForecast}`,
+    [sourceName, metric, start, end, showAnoms, showForecast],
   );
 
   // Filters UI
   const filters = (
     <FiltersBar
       Source={
-        <select data-testid="filter-source" value={sourceName} onChange={e=>setSourceName(e.target.value)}>
-          <option value="demo-source">demo-source</option>
+        <select
+          key={sourceNamesKey}
+          data-testid="filter-source"
+          value={sourceName || ""}
+          onChange={(e) => setSourceName(e.target.value)}
+          aria-label="Source"
+        >
+          {sources.length === 0 ? (
+            <option value="" disabled>
+              (no sources yet)
+            </option>
+          ) : (
+            sources.map((s) => (
+              <option key={s.id ?? s.name} value={s.name}>
+                {s.name}
+              </option>
+            ))
+          )}
         </select>
       }
       Metric={
-        <select data-testid="filter-metric" value={metric} onChange={e=>setMetric(e.target.value)}>
-          <option value="events_total">events_total</option>
+        <select
+          data-testid="filter-metric"
+          value={metric}
+          onChange={(e) => setMetric(e.target.value)}
+          aria-label="Metric"
+        >
+          {(metricOptions.length ? metricOptions : ["events_total"]).map(
+            (m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ),
+          )}
         </select>
       }
       Start={
-        <input data-testid="filter-start" type="date" value={start}
-               onChange={(e)=>setStart(e.target.value)} max={end || undefined} />
+        <input
+          data-testid="filter-start"
+          type="date"
+          value={start}
+          onChange={(e) => setStart(e.target.value)}
+          max={end || undefined}
+        />
       }
       End={
-        <input data-testid="filter-end" type="date" value={end}
-               onChange={(e)=>setEnd(e.target.value)} min={start || undefined} />
+        <input
+          data-testid="filter-end"
+          type="date"
+          value={end}
+          onChange={(e) => setEnd(e.target.value)}
+          min={start || undefined}
+        />
       }
       Apply={
-        <button data-testid="btn-run" className="sd-btn" onClick={() => {
-          // manual re-run: touch end to re-trigger effect without changing values
-          setEnd((e) => e);
-        }} disabled={loading}>
+        <button
+          data-testid="btn-run"
+          className="sd-btn"
+          onClick={() => {
+            setEnd((e) => e); // manual re-run
+          }}
+          disabled={loading}
+        >
           {loading ? "Running…" : "Run"}
         </button>
       }
       Reset={
-        <button data-testid="btn-reset" className="sd-btn ghost" disabled={loading} onClick={handleReset}>
+        <button
+          data-testid="btn-reset"
+          className="sd-btn ghost"
+          disabled={loading}
+          onClick={handleReset}
+        >
           Reset
         </button>
       }
       Extra={
         <div className="sd-stack row" style={{ gap: 10, alignItems: "center" }}>
-          <select data-testid="quick-range" value={dateRange}
-                  onChange={(e)=>setDateRange(e.target.value as any)}>
+          <select
+            data-testid="quick-range"
+            value={dateRange}
+            onChange={(e) => setDateRange(e.target.value as any)}
+          >
             <option value="7">Last 7 days</option>
             <option value="14">Last 14 days</option>
             <option value="30">Last 30 days</option>
           </select>
 
           <label className="small sd-muted">Window</label>
-          <input data-testid="anoms-window" type="number" min={3} max={60} value={windowN}
-                 onChange={(e)=>setWindowN(Math.max(3, Math.min(60, Number(e.target.value)||7)))}
-                 style={{ width: 64 }} />
+          <input
+            data-testid="anoms-window"
+            type="number"
+            min={3}
+            max={60}
+            value={windowN}
+            onChange={(e) =>
+              setWindowN(Math.max(3, Math.min(60, Number(e.target.value) || 7)))
+            }
+            style={{ width: 64 }}
+          />
 
           <label className="small sd-muted">z≥</label>
-          <input data-testid="anoms-z" type="number" step="0.1" min={0} max={6} value={zThresh}
-                 onChange={(e)=>setZThresh(Math.max(0, Math.min(6, Number(e.target.value)||3)))}
-                 style={{ width: 64 }} />
+          <input
+            data-testid="anoms-z"
+            type="number"
+            step="0.1"
+            min={0}
+            max={6}
+            value={zThresh}
+            onChange={(e) =>
+              setZThresh(Math.max(0, Math.min(6, Number(e.target.value) || 3)))
+            }
+            style={{ width: 64 }}
+          />
 
           <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <input data-testid="toggle-anoms" type="checkbox"
-                   checked={showAnoms} onChange={(e)=>setShowAnoms(e.target.checked)} />
+            <input
+              data-testid="toggle-anoms"
+              type="checkbox"
+              checked={showAnoms}
+              onChange={(e) => setShowAnoms(e.target.checked)}
+            />
             Show anomalies
           </label>
           <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <input data-testid="toggle-forecast" type="checkbox"
-                   checked={showForecast} onChange={(e)=>setShowForecast(e.target.checked)} />
+            <input
+              data-testid="toggle-forecast"
+              type="checkbox"
+              checked={showForecast}
+              onChange={(e) => {
+                const v = e.target.checked;
+                setShowForecast(v);
+                if (v) setFcTick((t) => t + 1);
+                else setForecast([]);
+              }}
+            />
             Show forecast
           </label>
+
+          {/* Upload */}
           <input
             ref={fileRef}
             type="file"
-            accept=".csv,text/csv"
+            accept=".csv,application/json,text/csv,application/vnd.ms-excel"
             style={{ display: "none" }}
-            onChange={(e)=>handleUpload(e.target.files?.[0] ?? null)}
+            onChange={(e) => handleUpload(e.target.files?.[0] ?? null)}
             data-testid="upload-file"
           />
           <button
@@ -405,7 +687,20 @@ export default function DashboardPage() {
           >
             {uploading ? "Uploading…" : "Upload CSV"}
           </button>
-          {uploadMsg && <span className="sd-text-xs sd-muted" aria-live="polite">{uploadMsg}</span>}
+          {uploadMsg && (
+            <span className="sd-text-xs sd-muted" aria-live="polite">
+              {uploadMsg}
+            </span>
+          )}
+
+          {/* Reload sources button */}
+          <button
+            className="sd-btn ghost"
+            type="button"
+            onClick={() => void loadSources()}
+          >
+            Reload sources
+          </button>
         </div>
       }
     />
@@ -419,28 +714,44 @@ export default function DashboardPage() {
       left={
         <div>
           <Text variant="h3">Daily KPIs ({metric})</Text>
-          {error && <Text variant="small" className="sd-my-2" muted>⚠️ {error}</Text>}
-          {rows.length === 0
-            ? <Text className="sd-my-2" muted>No data for this selection. Try a wider range.</Text>
-            : <div className="sd-my-2">
-                <MetricDailyChart
-                  key={chartKey}
-                  rows={rows.map(r=>({ date: getDate(r)||"", value: num(pick(r,"value_sum","sum","total","value")) }))}
-                  anomalies={anoms}
-                  forecast={forecast}
-                />
-                {/* hidden lists for test hooks */}
-                <ul data-testid="anomaly-list" style={{ display: "none" }}>
-                  {anoms.map((a, i) => (
-                    <li key={i} data-date={a.date} data-value={a.value} data-z={a.z ?? ""} />
-                  ))}
-                </ul>
-                <ul data-testid="forecast-list" style={{ display: "none" }}>
-                  {forecast.map((p, i) => (
-                    <li key={i} data-date={p.date} data-yhat={p.yhat} />
-                  ))}
-                </ul>
-              </div>}
+          {error && (
+            <Text variant="small" className="sd-my-2" muted>
+              ⚠️ {error}
+            </Text>
+          )}
+          {rows.length === 0 ? (
+            <Text className="sd-my-2" muted>
+              No data for this selection. Try a wider range.
+            </Text>
+          ) : (
+            <div className="sd-my-2">
+              <MetricDailyChart
+                key={chartKey}
+                rows={rows.map((r) => ({
+                  date: getDate(r) || "",
+                  value: num(pick(r, "value_sum", "sum", "total", "value")),
+                }))}
+                anomalies={anoms}
+                forecast={forecast}
+              />
+              {/* hidden lists for test hooks */}
+              <ul data-testid="anomaly-list" style={{ display: "none" }}>
+                {anoms.map((a, i) => (
+                  <li
+                    key={i}
+                    data-date={a.date}
+                    data-value={a.value}
+                    data-z={a.z ?? ""}
+                  />
+                ))}
+              </ul>
+              <ul data-testid="forecast-list" style={{ display: "none" }}>
+                {forecast.map((p, i) => (
+                  <li key={i} data-date={p.date} data-yhat={p.yhat} />
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       }
       right={<MetricDailyTableView rows={rows} />}


### PR DESCRIPTION
FR-6C: forecast overlay reliability + dynamic Sources
- DashboardPage: dynamic /api/sources + /api/metrics/names, cache-bust, safe dropdown remount
- Forecast: single refetch on toggle ON; clear on OFF; cache cleared on filter change
- Anomalies/forecast fetches abort on filter/toggle changes
- Reset normalizes filters & overlays
- Visual baseline updated; E2E suites green
- Trim dead frontend code (components/hooks); remove unused devDeps; repo hygiene