### PR TITLE
chore: fix backend imports via package marker + sitecustomize; note port 8000 conflict

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"Smart Data Pipeline backend package marker."

--- a/backend/sitecustomize.py
+++ b/backend/sitecustomize.py
@@ -1,0 +1,19 @@
+"""Ensure the project root is importable when running commands from backend/."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _ensure_project_root() -> None:
+    backend_dir = Path(__file__).resolve().parent
+    project_root = backend_dir.parent
+
+    # Prepend so local modules win over globally installed packages with same name.
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
+
+_ensure_project_root()


### PR DESCRIPTION
Added backend/__init__.py to mark the backend as a proper Python package and created backend/sitecustomize.py to prepend the project root to sys.path when running commands from within backend/. With these changes, uvicorn backend.app.main:app now resolves imports cleanly from the backend directory. The only remaining runtime blocker is an existing process bound to port 8000—stop it or launch on another port (e.g., uvicorn backend.app.main:app --port 8001). This improves local DX and stabilizes test/serve workflows on the branch chore/raise-backend-coverage-80.